### PR TITLE
Add WhatsApp messages for quickstart

### DIFF
--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.1.x.go
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.1.x.go
@@ -12,7 +12,7 @@ func main() {
 
 	router.POST("/whatsapp", func(context *gin.Context) {
 		message := &twiml.MessagingMessage{
-			Body: "Message received! Hello again from Twilio Whatsapp.",
+			Body: "Message received! Hello again from the Twilio Sandbox for WhatsApp.",
 		}
 
 		twimlResult, err := twiml.Messages([]twiml.Element{message})

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.1.x.go
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.1.x.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/twilio/twilio-go/twiml"
+)
+
+func main() {
+	router := gin.Default()
+
+	router.POST("/whatsapp", func(context *gin.Context) {
+		message := &twiml.MessagingMessage{
+			Body: "Message received! Hello again from Twilio Whatsapp.",
+		}
+
+		twimlResult, err := twiml.Messages([]twiml.Element{message})
+		if err != nil {
+			context.String(http.StatusInternalServerError, err.Error())
+		} else {
+			context.Header("Content-Type", "text/xml")
+			context.String(http.StatusOK, twimlResult)
+		}
+	})
+
+	router.Run(":3000")
+}

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.10.x.java
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.10.x.java
@@ -4,22 +4,22 @@ import com.twilio.twiml.messaging.Message;
 
 import static spark.Spark.*;
 
-public class SmsApp {
+public class WhatsAppApp {
     public static void main(String[] args) {
         get("/", (req, res) -> "Hello Web");
 
         post("/whatsapp", (req, res) -> {
             res.type("application/xml");
             Body body = new Body
-                    .Builder("Message received! Hello again from Twilio Whatsapp.")
+                    .Builder("Message received! Hello again from the Twilio Sandbox for WhatsApp.")
                     .build();
-            Message sms = new Message
+            Message whatsapp = new Message
                     .Builder()
                     .body(body)
                     .build();
             MessagingResponse twiml = new MessagingResponse
                     .Builder()
-                    .message(sms)
+                    .message(whatsapp)
                     .build();
             return twiml.toXml();
         });

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.10.x.java
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.10.x.java
@@ -1,0 +1,27 @@
+import com.twilio.twiml.MessagingResponse;
+import com.twilio.twiml.messaging.Body;
+import com.twilio.twiml.messaging.Message;
+
+import static spark.Spark.*;
+
+public class SmsApp {
+    public static void main(String[] args) {
+        get("/", (req, res) -> "Hello Web");
+
+        post("/whatsapp", (req, res) -> {
+            res.type("application/xml");
+            Body body = new Body
+                    .Builder("Message received! Hello again from Twilio Whatsapp.")
+                    .build();
+            Message sms = new Message
+                    .Builder()
+                    .body(body)
+                    .build();
+            MessagingResponse twiml = new MessagingResponse
+                    .Builder()
+                    .message(sms)
+                    .build();
+            return twiml.toXml();
+        });
+    }
+}

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.5.x.js
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.5.x.js
@@ -6,7 +6,7 @@ const app = express();
 app.post('/whatsapp', (req, res) => {
   const twiml = new MessagingResponse();
 
-  twiml.message('Message received! Hello again from Twilio Whatsapp.');
+  twiml.message('Message received! Hello again from the Twilio Sandbox for WhatsApp.');
 
   res.type('text/xml').send(twiml.toString());
 });

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.5.x.js
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.5.x.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const { MessagingResponse } = require('twilio').twiml;
+
+const app = express();
+
+app.post('/whatsapp', (req, res) => {
+  const twiml = new MessagingResponse();
+
+  twiml.message('Message received! Hello again from Twilio Whatsapp.');
+
+  res.type('text/xml').send(twiml.toString());
+});
+
+app.listen(3000, () => {
+  console.log('Express server listening on port 3000');
+});

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.6.x.cs
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.6.x.cs
@@ -13,7 +13,7 @@ namespace YourNewWebProject.Controllers
         public TwiMLResult Index()
         {
             var messagingResponse = new MessagingResponse();
-            messagingResponse.Message("Message received! Hello again from Twilio Whatsapp.");
+            messagingResponse.Message("Message received! Hello again from the Twilio Sandbox for WhatsApp.");
 
             return TwiML(messagingResponse);
         }

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.6.x.cs
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.6.x.cs
@@ -1,0 +1,21 @@
+// In Package Manager, run:
+// Install-Package Twilio.AspNet.Mvc -DependencyVersion HighestMinor
+
+using System.Web.Mvc;
+using Twilio.AspNet.Mvc;
+using Twilio.TwiML;
+
+namespace YourNewWebProject.Controllers
+{
+    public class WhatsappController : TwilioController
+    {
+        [HttpPost]
+        public TwiMLResult Index()
+        {
+            var messagingResponse = new MessagingResponse();
+            messagingResponse.Message("Message received! Hello again from Twilio Whatsapp.");
+
+            return TwiML(messagingResponse);
+        }
+    }
+}

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.7.x.rb
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.7.x.rb
@@ -4,7 +4,7 @@ require 'sinatra'
 # Respond to incoming calls with a simple text message
 post '/whatsapp' do
   twiml = Twilio::TwiML::MessagingResponse.new do |r|
-    r.message body: 'Message received! Hello again from Twilio Whatsapp.'
+    r.message body: 'Message received! Hello again from the Twilio Sandbox for WhatsApp.'
   end
 
   content_type 'text/xml'

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.7.x.rb
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.7.x.rb
@@ -1,0 +1,13 @@
+require 'twilio-ruby'
+require 'sinatra'
+
+# Respond to incoming calls with a simple text message
+post '/whatsapp' do
+  twiml = Twilio::TwiML::MessagingResponse.new do |r|
+    r.message body: 'Message received! Hello again from Twilio Whatsapp.'
+  end
+
+  content_type 'text/xml'
+
+  twiml.to_s
+end

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.8.x.php
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.8.x.php
@@ -5,5 +5,5 @@ require_once 'vendor/autoload.php'; // Loads the library
 use Twilio\TwiML\MessagingResponse;
 
 $response = new MessagingResponse();
-$response->message("Message received! Hello again from Twilio Whatsapp.");
+$response->message("Message received! Hello again from the Twilio Sandbox for WhatsApp.");
 print $response;

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.8.x.php
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.8.x.php
@@ -1,0 +1,9 @@
+<?php
+// Get the PHP helper library from https://twilio.com/docs/libraries/php
+
+require_once 'vendor/autoload.php'; // Loads the library
+use Twilio\TwiML\MessagingResponse;
+
+$response = new MessagingResponse();
+$response->message("Message received! Hello again from Twilio Whatsapp.");
+print $response;

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.9.x.py
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.9.x.py
@@ -1,0 +1,18 @@
+from flask import Flask, request, redirect
+from twilio.twiml.messaging_response import MessagingResponse
+
+app = Flask(__name__)
+
+@app.route("/whatsapp", methods=['GET', 'POST'])
+def sms_reply():
+    """Respond to incoming calls with a simple text message."""
+    # Start our TwiML response
+    resp = MessagingResponse()
+
+    # Add a message
+    resp.message("Message received! Hello again from Twilio Whatsapp.")
+
+    return str(resp)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.9.x.py
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.9.x.py
@@ -4,13 +4,13 @@ from twilio.twiml.messaging_response import MessagingResponse
 app = Flask(__name__)
 
 @app.route("/whatsapp", methods=['GET', 'POST'])
-def sms_reply():
+def whatsapp_reply():
     """Respond to incoming calls with a simple text message."""
     # Start our TwiML response
     resp = MessagingResponse()
 
     # Add a message
-    resp.message("Message received! Hello again from Twilio Whatsapp.")
+    resp.message("Message received! Hello again from the Twilio Sandbox for WhatsApp.")
 
     return str(resp)
 

--- a/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.yml
+++ b/rest/messages/generate-twiml-whatsapp/generate-twiml-whatsapp.yml
@@ -1,0 +1,1 @@
+testable: false

--- a/rest/messages/generate-twiml-whatsapp/meta.json
+++ b/rest/messages/generate-twiml-whatsapp/meta.json
@@ -1,0 +1,6 @@
+{
+  "testable": "false",
+  "type": "server",
+  "title": "Respond to an incoming WhatsApp message",
+  "description": "When the Twilio Sandbox for WhatsApp receives an incoming message, Twilio will send an HTTP request to your server. This code shows how your server can reply with a WhatsApp message using the Twilio helper library."
+}


### PR DESCRIPTION
Add WhatsApp quickstart snippets for https://github.com/twilio-internal/docs/pull/4379.

These code samples are duplicates of https://github.com/twilio-samples/api-snippets/tree/main/rest/messages/generate-twiml-sms with the exception that the `to` and `from` values have the `whatsapp:` prefix.